### PR TITLE
Add text fill to legend

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -465,6 +465,7 @@ class FHeatmap {
                     .text((_, i) => column.palette.colorNames[i])
                     .attr('font-size', O.legendFontSize)
                     .attr('dominant-baseline', 'central')
+                    .style('fill', O.theme.textColor)
                     .attr('transform', d => {
                         const p = d3.arc().innerRadius(O.geomSize / 2).outerRadius(O.geomSize).centroid(d);
                         p[0] += O.geomSize / 2 + 4 * O.geomPadding;


### PR DESCRIPTION
This PR adds a text fill to the pie legend in order to fix https://github.com/openproblems-bio/website/pull/309.

Without it, the pie legend looks like this:

![Screenshot from 2024-02-15 05-36-47](https://github.com/funkyheatmap/funkyheatmapjs/assets/553642/b30d6a49-9693-479f-ac5a-bccabf0907d3)
